### PR TITLE
Typos and continuity

### DIFF
--- a/chapter1.md
+++ b/chapter1.md
@@ -456,31 +456,30 @@ impl BytePacketBuffer {
 
                 continue;
             }
+
             // The base scenario, where we're reading a single label and
             // appending it to the output:
-            else {
-                // Move a single byte forward to move past the length byte.
-                pos += 1;
+						// Move a single byte forward to move past the length byte.
+						pos += 1;
 
-                // Domain names are terminated by an empty label of length 0,
-                // so if the length is zero we're done.
-                if len == 0 {
-                    break;
-                }
+						// Domain names are terminated by an empty label of length 0,
+						// so if the length is zero we're done.
+						if len == 0 {
+								break;
+						}
 
-                // Append the delimiter to our output buffer first.
-                outstr.push_str(delim);
+						// Append the delimiter to our output buffer first.
+						outstr.push_str(delim);
 
-                // Extract the actual ASCII bytes for this label and append them
-                // to the output buffer.
-                let str_buffer = self.get_range(pos, len as usize)?;
-                outstr.push_str(&String::from_utf8_lossy(str_buffer).to_lowercase());
+						// Extract the actual ASCII bytes for this label and append them
+						// to the output buffer.
+						let str_buffer = self.get_range(pos, len as usize)?;
+						outstr.push_str(&String::from_utf8_lossy(str_buffer).to_lowercase());
 
-                delim = ".";
+						delim = ".";
 
-                // Move forward the full length of the label.
-                pos += len as usize;
-            }
+						// Move forward the full length of the label.
+						pos += len as usize;
         }
 
         if !jumped {

--- a/examples/sample1.rs
+++ b/examples/sample1.rs
@@ -138,31 +138,30 @@ impl BytePacketBuffer {
 
                 continue;
             }
+
             // The base scenario, where we're reading a single label and
             // appending it to the output:
-            else {
-                // Move a single byte forward to move past the length byte.
-                pos += 1;
+            // Move a single byte forward to move past the length byte.
+            pos += 1;
 
-                // Domain names are terminated by an empty label of length 0,
-                // so if the length is zero we're done.
-                if len == 0 {
-                    break;
-                }
-
-                // Append the delimiter to our output buffer first.
-                outstr.push_str(delim);
-
-                // Extract the actual ASCII bytes for this label and append them
-                // to the output buffer.
-                let str_buffer = self.get_range(pos, len as usize)?;
-                outstr.push_str(&String::from_utf8_lossy(str_buffer).to_lowercase());
-
-                delim = ".";
-
-                // Move forward the full length of the label.
-                pos += len as usize;
+            // Domain names are terminated by an empty label of length 0,
+            // so if the length is zero we're done.
+            if len == 0 {
+                break;
             }
+
+            // Append the delimiter to our output buffer first.
+            outstr.push_str(delim);
+
+            // Extract the actual ASCII bytes for this label and append them
+            // to the output buffer.
+            let str_buffer = self.get_range(pos, len as usize)?;
+            outstr.push_str(&String::from_utf8_lossy(str_buffer).to_lowercase());
+
+            delim = ".";
+
+            // Move forward the full length of the label.
+            pos += len as usize;
         }
 
         if !jumped {

--- a/examples/sample2.rs
+++ b/examples/sample2.rs
@@ -166,7 +166,7 @@ impl BytePacketBuffer {
     fn write_qname(&mut self, qname: &str) -> Result<()> {
         for label in qname.split('.') {
             let len = label.len();
-            if len > 0x34 {
+            if len > 0x3f {
                 return Err("Single label exceeds 63 characters of length".into());
             }
 

--- a/examples/sample3.rs
+++ b/examples/sample3.rs
@@ -166,7 +166,7 @@ impl BytePacketBuffer {
     fn write_qname(&mut self, qname: &str) -> Result<()> {
         for label in qname.split('.') {
             let len = label.len();
-            if len > 0x34 {
+            if len > 0x3f {
                 return Err("Single label exceeds 63 characters of length".into());
             }
 

--- a/examples/sample4.rs
+++ b/examples/sample4.rs
@@ -166,7 +166,7 @@ impl BytePacketBuffer {
     fn write_qname(&mut self, qname: &str) -> Result<()> {
         for label in qname.split('.') {
             let len = label.len();
-            if len > 0x34 {
+            if len > 0x3f {
                 return Err("Single label exceeds 63 characters of length".into());
             }
 

--- a/examples/sample5.rs
+++ b/examples/sample5.rs
@@ -166,7 +166,7 @@ impl BytePacketBuffer {
     fn write_qname(&mut self, qname: &str) -> Result<()> {
         for label in qname.split('.') {
             let len = label.len();
-            if len > 0x34 {
+            if len > 0x3f {
                 return Err("Single label exceeds 63 characters of length".into());
             }
 


### PR DESCRIPTION
Change Chapter1.md, and Sample1.rs to reflect the changes later made in Samples 2-5. It helps with debugging when following along manually. 

Also fat-finger typos in samples 2-5:

0x34 -> 0x3f for 63 character qname limit.


Thanks a ton for making this! It was a lot of fun!